### PR TITLE
Fix WSKR.EXE missing message

### DIFF
--- a/Wskr GUI/wskrgui_unit.pas
+++ b/Wskr GUI/wskrgui_unit.pas
@@ -361,7 +361,7 @@ begin
   WSKrEXE := ExtractFilePath(ParamStr(0)) + 'wskr.exe';
   if not FileExists(WSKrEXE) then
   begin
-    ShowMessage('WSKR.EXE not found at:- '+ExtractFilePath(ParamStr(0)));
+    ShowMessage('WSKR.EXE not found at: '+ExtractFilePath(ParamStr(0)));
     WSKrEXE := '';
   end;
 end;


### PR DESCRIPTION
## Summary
- update missing executable warning in `FormCreate`

## Testing
- `fpc 'Wskr GUI/wskrgui.lpr'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f74260b2083249df2ffe0b051411d