### PR TITLE
Fix uninitialized return in SaveMemoToTempFile

### DIFF
--- a/Wskr GUI/wskrgui_unit.pas
+++ b/Wskr GUI/wskrgui_unit.pas
@@ -332,6 +332,7 @@ begin
   if TempFolder = '' then
   begin
     ShowMessage('Unable to locate the temporary folder.');
+    Result := '';
     Exit;
   end;
 


### PR DESCRIPTION
## Summary
- ensure SaveMemoToTempFile always returns a defined string when `%TEMP%` is missing

## Testing
- `fpc -h` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f70f38e7c83248be0b2b7bddce599